### PR TITLE
test(e2e): add user authentication tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,6 +53,71 @@ jobs:
       - name: Upload Coverage
         run: yarn codecov
 
+  test_e2e:
+    name: E2E Test
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgresql://test_db_user:test_db_password@localhost:5432/tell_me?schema=public
+      NODE_ENV: production
+    services:
+      db:
+        image: postgres:14
+        env:
+          POSTGRES_DB: tell_me
+          POSTGRES_USER: test_db_user
+          POSTGRES_PASSWORD: test_db_password
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Cache
+        if: ${{ always() }}
+        id: cache
+        uses: actions/cache@v3
+        # https://playwright.dev/docs/ci#directories-to-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            **/.next/cache
+          key: ${{ hashFiles('**/yarn.lock') }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: 16
+      - name: Install
+        run: yarn --frozen-lockfile --production=false
+      - name: Install Playwright browsers
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        run: |
+          npx playwright install-deps chromium
+          npx playwright install chromium
+      - name: Setup CI
+        run: yarn ci:e2e:setup
+      - name: Build
+        run: yarn build
+      - name: Serve
+        run: yarn start &
+      - name: Wait for server
+        # https://stackoverflow.com/a/50055449/2736233
+        run: timeout 30 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' localhost 3000
+      - name: Run end-to-end tests
+        run: yarn test:e2e
+      - name: Archive failed tests trace
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: |
+            ./test-results
+
   docker:
     name: Docker
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -136,10 +136,17 @@ sketch
 ################################################################################
 # Custom
 
-/.env.local
+# Playwright storage states
+/e2e/states/*
+!/e2e/states/README.md
 
+# Tell Me users assets (when not using an external static server)
 /assets/*
 !/assets/README.md
 !/assets/private
 /assets/private/*
 !/assets/private/README.md
+
+# Playwright traces
+/test-results
+/test-results.zip

--- a/api/helpers/isReady.ts
+++ b/api/helpers/isReady.ts
@@ -1,5 +1,6 @@
 import { handleError } from '@common/helpers/handleError'
-import { PrismaClient } from '@prisma/client'
+
+import { prisma } from '../libs/prisma'
 
 // Optimize subsequent requests once it's `true`
 let IS_READY = false
@@ -7,9 +8,8 @@ let IS_READY = false
 export async function isReady(): Promise<boolean> {
   try {
     if (!IS_READY) {
-      const prismaInstance = new PrismaClient()
-      const usersCount = await prismaInstance.user.count()
-      await prismaInstance.$disconnect()
+      const usersCount = await prisma.user.count()
+      await prisma.$disconnect()
 
       IS_READY = usersCount > 0
     }

--- a/app/organisms/Menu.tsx
+++ b/app/organisms/Menu.tsx
@@ -140,10 +140,25 @@ export function Menu() {
       </div>
 
       <UserMenu>
-        <Link href="/me">
+        <Link
+          aria-label={intl.formatMessage({
+            defaultMessage: 'My settings',
+            description: '[Menu] Settings button aria label.',
+            id: 'MENU__SETTINGS_BUTTON_ARIA_LABEL',
+          })}
+          href="/me"
+        >
           <Settings />
         </Link>
-        <LogOut onClick={auth.logOut} />
+        <LogOut
+          aria-label={intl.formatMessage({
+            defaultMessage: 'Log out',
+            description: '[Menu] Log out button aria label.',
+            id: 'MENU__LOG_OUT_BUTTON_ARIA_LABEL',
+          })}
+          onClick={auth.logOut}
+          role="button"
+        />
       </UserMenu>
     </Container>
   )

--- a/config/playwright.config.ts
+++ b/config/playwright.config.ts
@@ -1,0 +1,48 @@
+import { devices } from '@playwright/test'
+
+import type { PlaywrightTestConfig } from '@playwright/test'
+
+const { CI } = process.env
+const IS_CI = Boolean(CI)
+
+const config: PlaywrightTestConfig = {
+  expect: {
+    timeout: IS_CI ? 10000 : 30000,
+  },
+  forbidOnly: IS_CI,
+  globalSetup: './playwright.setup.ts',
+  maxFailures: 1,
+  projects: [
+    {
+      name: 'CHROME DESKTOP',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: {
+          height: 720,
+          width: 1280,
+        },
+      },
+    },
+  ],
+  reportSlowTests: null,
+  retries: 2,
+  testDir: '../e2e',
+  timeout: 30000,
+  use: {
+    bypassCSP: true,
+    headless: IS_CI,
+    locale: 'en-US',
+    timezoneId: 'America/Los_Angeles',
+    trace: 'retain-on-failure',
+    video: {
+      mode: 'retain-on-failure',
+      size: {
+        height: 720 * 2,
+        width: 1280 * 2,
+      },
+    },
+  },
+  workers: 1,
+}
+
+export default config

--- a/config/playwright.setup.ts
+++ b/config/playwright.setup.ts
@@ -1,0 +1,59 @@
+/* eslint-disable no-await-in-loop */
+
+import prismaClientPkg from '@prisma/client'
+import dotenv from 'dotenv'
+
+import { TEST_USERS } from '../e2e/constants.js'
+
+dotenv.config()
+
+const { CI } = process.env
+const IS_CI = Boolean(CI)
+
+const { PrismaClient } = prismaClientPkg
+
+export default async function globalSetup() {
+  if (IS_CI) {
+    return
+  }
+
+  const prisma = new PrismaClient()
+
+  for (const testUser of TEST_USERS) {
+    const user = await prisma.user.findUnique({
+      where: {
+        email: testUser.email,
+      },
+    })
+
+    if (user === null) {
+      continue
+    }
+
+    await prisma.personalAccessToken.deleteMany({
+      where: {
+        userId: user.id,
+      },
+    })
+
+    await prisma.survey.deleteMany({
+      where: {
+        userId: user.id,
+      },
+    })
+
+    await prisma.refreshToken.deleteMany({
+      where: {
+        userId: user.id,
+      },
+    })
+
+    await prisma.user.delete({
+      where: {
+        email: testUser.email,
+      },
+    })
+  }
+
+  await prisma.$disconnect()
+}

--- a/e2e/101-sanity-check.spec.ts
+++ b/e2e/101-sanity-check.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Sanity Check', () => {
+  test('API', async ({ request }) => {
+    const response = await request.get('http://localhost:3000/api')
+    const data = await response.json()
+
+    expect(response.ok()).toBe(true)
+    expect(data).toMatchObject({
+      data: {
+        isReady: false,
+        version: '0.0.0',
+      },
+    })
+  })
+
+  test('Home', async ({ page }) => {
+    await page.goto('http://localhost:3000')
+
+    await expect(page.locator('h4')).toHaveText('Log In')
+  })
+})

--- a/e2e/201-signup.spec.ts
+++ b/e2e/201-signup.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test'
+import prismaClientPkg, { UserRole } from '@prisma/client'
+
+import { TEST_USERS } from './constants.js'
+
+const { PrismaClient } = prismaClientPkg
+
+test.describe('Authentication', () => {
+  test('First User (= Administrator) Signup', async ({ page }) => {
+    const prisma = new PrismaClient()
+    const testAdministrationUser = TEST_USERS[0]
+
+    await page.goto('http://localhost:3000')
+
+    await expect(page.locator('h4')).toHaveText('Log In')
+
+    await page.click('button:has-text("sign up")')
+
+    await expect(page.locator('h4')).toHaveText('Sign Up')
+
+    await page.fill('"Your email"', testAdministrationUser.email)
+    await page.fill('"A new password"', testAdministrationUser.password)
+    await page.fill('"Your new password (again)"', testAdministrationUser.password)
+    await page.click('button:has-text("Sign Up")')
+
+    await expect(page.locator('h4')).toHaveText('Log In')
+
+    const userCount = await prisma.user.count()
+
+    if (userCount > 0) {
+      await prisma.user.update({
+        data: {
+          isActive: true,
+          role: UserRole.ADMINISTRATOR,
+        },
+        where: {
+          email: testAdministrationUser.email,
+        },
+      })
+    }
+  })
+})

--- a/e2e/202-login.spec.ts
+++ b/e2e/202-login.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test'
+
+import { TEST_USERS } from './constants.js'
+
+test.describe('Authentication', () => {
+  test('Administrator Login', async ({ context, page }) => {
+    const testAdministrationUser = TEST_USERS[0]
+
+    await page.goto('http://localhost:3000')
+
+    await expect(page.locator('h4')).toHaveText('Log In')
+
+    // Wrong email and password:
+
+    await page.fill('"Email"', 'bruce.shark@sea.com')
+    await page.fill('"Password"', 'bruce')
+    await page.click('button:has-text("Log In")')
+
+    await expect(page.locator('.Error')).toHaveText('Wrong email and/or password.')
+
+    // Right email and wrong password:
+
+    await page.fill('"Email"', testAdministrationUser.email)
+    await page.click('button:has-text("Log In")')
+
+    await expect(page.locator('.Error')).toHaveText('Wrong email and/or password.')
+
+    // Right email and password:
+
+    await page.fill('"Password"', testAdministrationUser.password)
+    await page.click('button:has-text("Log In")')
+
+    await expect(page.locator('h1')).toHaveText('Dashboard')
+
+    await context.storageState({
+      path: './e2e/states/administrator.json',
+    })
+  })
+})

--- a/e2e/203-logout.spec.ts
+++ b/e2e/203-logout.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test'
+
+import { TEST_USERS } from './constants.js'
+
+test.describe('Authentication', () => {
+  test.use({
+    storageState: './e2e/states/administrator.json',
+  })
+
+  test('Administration User Logout', async ({ context, page }) => {
+    const testAdministrationUser = TEST_USERS[0]
+
+    await page.goto('http://localhost:3000')
+
+    await expect(page.locator('h1')).toHaveText('Dashboard')
+
+    await page.click('[aria-label="Log out"]')
+
+    await expect(page.locator('h4')).toHaveText('Log In')
+
+    // We log in again to prepare next authenticated tests:
+
+    await page.fill('"Email"', testAdministrationUser.email)
+    await page.fill('"Password"', testAdministrationUser.password)
+    await page.click('button:has-text("Log In")')
+
+    await expect(page.locator('h1')).toHaveText('Dashboard')
+
+    await context.storageState({
+      path: './e2e/states/administrator.json',
+    })
+  })
+})

--- a/e2e/END.spec.ts
+++ b/e2e/END.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test'
+import { PrismaClient } from '@prisma/client'
+import { B } from 'bhala'
+
+import { TEST_USERS } from './constants.js'
+
+test.describe('END', () => {
+  test('END', async () => {
+    expect(1 + 1).toBe(2)
+  })
+
+  test.afterAll(async () => {
+    const prisma = new PrismaClient()
+
+    for (const testUser of TEST_USERS) {
+      const user = await prisma.user.findUnique({
+        where: {
+          email: testUser.email,
+        },
+      })
+
+      if (user === null) {
+        continue
+      }
+
+      await prisma.personalAccessToken.deleteMany({
+        where: {
+          userId: user.id,
+        },
+      })
+
+      await prisma.survey.deleteMany({
+        where: {
+          userId: user.id,
+        },
+      })
+
+      await prisma.refreshToken.deleteMany({
+        where: {
+          userId: user.id,
+        },
+      })
+
+      await prisma.user.delete({
+        where: {
+          email: testUser.email,
+        },
+      })
+    }
+
+    const userCount = await prisma.user.count()
+    B.info(`\n${userCount} user(s) left.`)
+
+    await prisma.$disconnect()
+  })
+})

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -1,0 +1,10 @@
+export const TEST_USERS = [
+  {
+    email: 'doris.fish@sea.com',
+    password: 'doris',
+  },
+  {
+    email: 'nemo.fish@sea.com',
+    password: 'nemo',
+  },
+]

--- a/e2e/states/README.md
+++ b/e2e/states/README.md
@@ -1,0 +1,5 @@
+# Playwright Storage States
+
+Playwright storage states are stored here to re-inject them as authenticated contexts before each test.
+
+See: <https://playwright.dev/docs/test-auth#reuse-signed-in-state>.

--- a/locales/compiled/en-US.json
+++ b/locales/compiled/en-US.json
@@ -119,6 +119,48 @@
       "value": "Email"
     }
   ],
+  "LOGIN_DIALOG__DISABLED_ACCOUNT_ERROR": [
+    {
+      "type": 0,
+      "value": "Your account has not yet been activated."
+    }
+  ],
+  "LOGIN_DIALOG__EMAIL_INPUT_FORMAT_ERROR": [
+    {
+      "type": 0,
+      "value": "Your email doesn't look right."
+    }
+  ],
+  "LOGIN_DIALOG__EMAIL_INPUT_REQUIREMENT_ERROR": [
+    {
+      "type": 0,
+      "value": "Please enter your email."
+    }
+  ],
+  "LOGIN_DIALOG__PASSWORD_INPUT_REQUIREMENT_ERROR": [
+    {
+      "type": 0,
+      "value": "Please enter your password."
+    }
+  ],
+  "LOGIN_DIALOG__WRONG_CREDENTIALS_ERROR": [
+    {
+      "type": 0,
+      "value": "Wrong email and/or password."
+    }
+  ],
+  "MENU__LOG_OUT_BUTTON_ARIA_LABEL": [
+    {
+      "type": 0,
+      "value": "Log out"
+    }
+  ],
+  "MENU__SETTINGS_BUTTON_ARIA_LABEL": [
+    {
+      "type": 0,
+      "value": "My settings"
+    }
+  ],
   "NIzhyl": [
     {
       "type": 0,
@@ -147,6 +189,42 @@
     {
       "type": 0,
       "value": "New PAT"
+    }
+  ],
+  "SIGNUP_DIALOG__DUPLICATE_ACCOUNT_ERROR": [
+    {
+      "type": 0,
+      "value": "This email is already associated with an existing account."
+    }
+  ],
+  "SIGNUP_DIALOG__EMAIL_INPUT_FORMAT_ERROR": [
+    {
+      "type": 0,
+      "value": "Your email doesn't look right."
+    }
+  ],
+  "SIGNUP_DIALOG__EMAIL_INPUT_REQUIREMENT_ERROR": [
+    {
+      "type": 0,
+      "value": "Please enter your email."
+    }
+  ],
+  "SIGNUP_DIALOG__PASSWORD_CONFIRMATION_INPUT_MATCH_ERROR": [
+    {
+      "type": 0,
+      "value": "Passwords don't match."
+    }
+  ],
+  "SIGNUP_DIALOG__PASSWORD_CONFIRMATION_INPUT_REQUIREMENT_ERROR": [
+    {
+      "type": 0,
+      "value": "Please enter your password."
+    }
+  ],
+  "SIGNUP_DIALOG__PASSWORD_INPUT_REQUIREMENT_ERROR": [
+    {
+      "type": 0,
+      "value": "Please enter your password."
     }
   ],
   "TYZzVl": [

--- a/locales/compiled/fr-FR.json
+++ b/locales/compiled/fr-FR.json
@@ -119,6 +119,48 @@
       "value": "Email"
     }
   ],
+  "LOGIN_DIALOG__DISABLED_ACCOUNT_ERROR": [
+    {
+      "type": 0,
+      "value": "Votre compte n'a pas encore été activé."
+    }
+  ],
+  "LOGIN_DIALOG__EMAIL_INPUT_FORMAT_ERROR": [
+    {
+      "type": 0,
+      "value": "Votre email semble mal formaté."
+    }
+  ],
+  "LOGIN_DIALOG__EMAIL_INPUT_REQUIREMENT_ERROR": [
+    {
+      "type": 0,
+      "value": "Veuillez entrer votre email."
+    }
+  ],
+  "LOGIN_DIALOG__PASSWORD_INPUT_REQUIREMENT_ERROR": [
+    {
+      "type": 0,
+      "value": "Veuillez entrer votre mot de passe."
+    }
+  ],
+  "LOGIN_DIALOG__WRONG_CREDENTIALS_ERROR": [
+    {
+      "type": 0,
+      "value": "Mauvais email et/ou mot de passe."
+    }
+  ],
+  "MENU__LOG_OUT_BUTTON_ARIA_LABEL": [
+    {
+      "type": 0,
+      "value": "Me déconnecter"
+    }
+  ],
+  "MENU__SETTINGS_BUTTON_ARIA_LABEL": [
+    {
+      "type": 0,
+      "value": "Mes préférences"
+    }
+  ],
   "NIzhyl": [
     {
       "type": 0,
@@ -147,6 +189,42 @@
     {
       "type": 0,
       "value": "Création d’un jeton d’accès personnel"
+    }
+  ],
+  "SIGNUP_DIALOG__DUPLICATE_ACCOUNT_ERROR": [
+    {
+      "type": 0,
+      "value": "Cette adresse email est déjà associée à un compte."
+    }
+  ],
+  "SIGNUP_DIALOG__EMAIL_INPUT_FORMAT_ERROR": [
+    {
+      "type": 0,
+      "value": "Votre email semble mal formaté."
+    }
+  ],
+  "SIGNUP_DIALOG__EMAIL_INPUT_REQUIREMENT_ERROR": [
+    {
+      "type": 0,
+      "value": "Veuillez entrer votre email."
+    }
+  ],
+  "SIGNUP_DIALOG__PASSWORD_CONFIRMATION_INPUT_MATCH_ERROR": [
+    {
+      "type": 0,
+      "value": "Les mots de passe ne correspondent pas."
+    }
+  ],
+  "SIGNUP_DIALOG__PASSWORD_CONFIRMATION_INPUT_REQUIREMENT_ERROR": [
+    {
+      "type": 0,
+      "value": "Veuillez répéter le mot de passe."
+    }
+  ],
+  "SIGNUP_DIALOG__PASSWORD_INPUT_REQUIREMENT_ERROR": [
+    {
+      "type": 0,
+      "value": "Veuillez entrer votre mot de passe."
     }
   ],
   "TYZzVl": [

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -53,7 +53,7 @@
   },
   "EYeJTo": {
     "defaultMessage": "Sign Up",
-    "description": "[Signup Modal] Title."
+    "description": "[Signup Dialog] Title."
   },
   "FC8ax/": {
     "defaultMessage": "Edit user",
@@ -65,7 +65,7 @@
   },
   "I8y4ic": {
     "defaultMessage": "Log In",
-    "description": "[Login Modal] Form submit button label."
+    "description": "[Login Dialog] Form submit button label."
   },
   "IEpCqZ": {
     "defaultMessage": "New survey",
@@ -73,11 +73,39 @@
   },
   "K06DbM": {
     "defaultMessage": "Your new password (again)",
-    "description": "[Signup Modal] Password repeat input label."
+    "description": "[Signup Dialog] Password repeat input label."
   },
   "KahMf6": {
     "defaultMessage": "Email",
     "description": "[Personal Access Tokens List] Table Email column label."
+  },
+  "LOGIN_DIALOG__DISABLED_ACCOUNT_ERROR": {
+    "defaultMessage": "Your account has not yet been activated.",
+    "description": "[Login Dialog] Disabled account error."
+  },
+  "LOGIN_DIALOG__EMAIL_INPUT_FORMAT_ERROR": {
+    "defaultMessage": "Your email doesn't look right.",
+    "description": "[Login Dialog] Email input format error."
+  },
+  "LOGIN_DIALOG__EMAIL_INPUT_REQUIREMENT_ERROR": {
+    "defaultMessage": "Please enter your email.",
+    "description": "[Login Dialog] Email input requirement error."
+  },
+  "LOGIN_DIALOG__PASSWORD_INPUT_REQUIREMENT_ERROR": {
+    "defaultMessage": "Please enter your password.",
+    "description": "[Login Dialog] Password input requirement error."
+  },
+  "LOGIN_DIALOG__WRONG_CREDENTIALS_ERROR": {
+    "defaultMessage": "Wrong email and/or password.",
+    "description": "[Login Dialog] Wrong creadentials error."
+  },
+  "MENU__LOG_OUT_BUTTON_ARIA_LABEL": {
+    "defaultMessage": "Log out",
+    "description": "[Menu] Log out button aria label."
+  },
+  "MENU__SETTINGS_BUTTON_ARIA_LABEL": {
+    "defaultMessage": "My settings",
+    "description": "[Menu] Settings button aria label."
   },
   "NIzhyl": {
     "defaultMessage": "New personal access token",
@@ -98,6 +126,30 @@
   "QWfMAC": {
     "defaultMessage": "New PAT",
     "description": "[Personal Access Token Editor] Creation page title."
+  },
+  "SIGNUP_DIALOG__DUPLICATE_ACCOUNT_ERROR": {
+    "defaultMessage": "This email is already associated with an existing account.",
+    "description": "[Signup Dialog] Duplicate account error."
+  },
+  "SIGNUP_DIALOG__EMAIL_INPUT_FORMAT_ERROR": {
+    "defaultMessage": "Your email doesn't look right.",
+    "description": "[Signup Dialog] Email input format error."
+  },
+  "SIGNUP_DIALOG__EMAIL_INPUT_REQUIREMENT_ERROR": {
+    "defaultMessage": "Please enter your email.",
+    "description": "[Signup Dialog] Email input requirement error."
+  },
+  "SIGNUP_DIALOG__PASSWORD_CONFIRMATION_INPUT_MATCH_ERROR": {
+    "defaultMessage": "Passwords don't match.",
+    "description": "[Signup Dialog] Password confirmation input match error."
+  },
+  "SIGNUP_DIALOG__PASSWORD_CONFIRMATION_INPUT_REQUIREMENT_ERROR": {
+    "defaultMessage": "Please enter your password.",
+    "description": "[Signup Dialog] Password confirmation input requirement error."
+  },
+  "SIGNUP_DIALOG__PASSWORD_INPUT_REQUIREMENT_ERROR": {
+    "defaultMessage": "Please enter your password.",
+    "description": "[Signup Dialog] Password input requirement error."
   },
   "TYZzVl": {
     "defaultMessage": "Label",
@@ -121,7 +173,7 @@
   },
   "YJ9OxG": {
     "defaultMessage": "Your email",
-    "description": "[Signup Modal] Email input label."
+    "description": "[Signup Dialog] Email input label."
   },
   "YsRqXk": {
     "defaultMessage": "Export as CSV",
@@ -153,7 +205,7 @@
   },
   "fWOJDC": {
     "defaultMessage": "A new password",
-    "description": "[Signup Modal] Password input label."
+    "description": "[Signup Dialog] Password input label."
   },
   "h4+RiJ": {
     "defaultMessage": "Update",
@@ -201,7 +253,7 @@
   },
   "q5x9RM": {
     "defaultMessage": "Sign Up",
-    "description": "[Signup Modal] Submit button label."
+    "description": "[Signup Dialog] Submit button label."
   },
   "s1Q3aH": {
     "defaultMessage": "Date",
@@ -213,15 +265,15 @@
   },
   "ugMu4J": {
     "defaultMessage": "Email",
-    "description": "[Login Modal] Form email input label."
+    "description": "[Login Dialog] Form email input label."
   },
   "wHB27C": {
     "defaultMessage": "Log In",
-    "description": "[Login Modal] Modal title."
+    "description": "[Login Dialog] Modal title."
   },
   "xhJCpr": {
     "defaultMessage": "Password",
-    "description": "[Login Modal] Form password input label."
+    "description": "[Login Dialog] Form password input label."
   },
   "zGNJ13": {
     "defaultMessage": "Users",

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -53,7 +53,7 @@
   },
   "EYeJTo": {
     "defaultMessage": "Inscription",
-    "description": "[Signup Modal] Title."
+    "description": "[Signup Dialog] Title."
   },
   "FC8ax/": {
     "defaultMessage": "Édition d’un·e utilisateur·rice",
@@ -65,7 +65,7 @@
   },
   "I8y4ic": {
     "defaultMessage": "Se connecter",
-    "description": "[Login Modal] Form submit button label."
+    "description": "[Login Dialog] Form submit button label."
   },
   "IEpCqZ": {
     "defaultMessage": "Nouveau questionnaire",
@@ -73,11 +73,39 @@
   },
   "K06DbM": {
     "defaultMessage": "Répêtez votre nouveau mot de passe",
-    "description": "[Signup Modal] Password repeat input label."
+    "description": "[Signup Dialog] Password repeat input label."
   },
   "KahMf6": {
     "defaultMessage": "Email",
     "description": "[Personal Access Tokens List] Table Email column label."
+  },
+  "LOGIN_DIALOG__DISABLED_ACCOUNT_ERROR": {
+    "defaultMessage": "Votre compte n'a pas encore été activé.",
+    "description": "[Login Dialog] Disabled account error."
+  },
+  "LOGIN_DIALOG__EMAIL_INPUT_FORMAT_ERROR": {
+    "defaultMessage": "Votre email semble mal formaté.",
+    "description": "[Login Dialog] Email input format error."
+  },
+  "LOGIN_DIALOG__EMAIL_INPUT_REQUIREMENT_ERROR": {
+    "defaultMessage": "Veuillez entrer votre email.",
+    "description": "[Login Dialog] Email input requirement error."
+  },
+  "LOGIN_DIALOG__PASSWORD_INPUT_REQUIREMENT_ERROR": {
+    "defaultMessage": "Veuillez entrer votre mot de passe.",
+    "description": "[Login Dialog] Password input requirement error."
+  },
+  "LOGIN_DIALOG__WRONG_CREDENTIALS_ERROR": {
+    "defaultMessage": "Mauvais email et/ou mot de passe.",
+    "description": "[Login Dialog] Wrong creadentials error."
+  },
+  "MENU__LOG_OUT_BUTTON_ARIA_LABEL": {
+    "defaultMessage": "Me déconnecter",
+    "description": "[Menu] Log out button aria label."
+  },
+  "MENU__SETTINGS_BUTTON_ARIA_LABEL": {
+    "defaultMessage": "Mes préférences",
+    "description": "[Menu] Settings button aria label."
   },
   "NIzhyl": {
     "defaultMessage": "Nouveau jeton d’accès personnel",
@@ -98,6 +126,30 @@
   "QWfMAC": {
     "defaultMessage": "Création d’un jeton d’accès personnel",
     "description": "[Personal Access Token Editor] Creation page title."
+  },
+  "SIGNUP_DIALOG__DUPLICATE_ACCOUNT_ERROR": {
+    "defaultMessage": "Cette adresse email est déjà associée à un compte.",
+    "description": "[Signup Dialog] Duplicate account error."
+  },
+  "SIGNUP_DIALOG__EMAIL_INPUT_FORMAT_ERROR": {
+    "defaultMessage": "Votre email semble mal formaté.",
+    "description": "[Signup Dialog] Email input format error."
+  },
+  "SIGNUP_DIALOG__EMAIL_INPUT_REQUIREMENT_ERROR": {
+    "defaultMessage": "Veuillez entrer votre email.",
+    "description": "[Signup Dialog] Email input requirement error."
+  },
+  "SIGNUP_DIALOG__PASSWORD_CONFIRMATION_INPUT_MATCH_ERROR": {
+    "defaultMessage": "Les mots de passe ne correspondent pas.",
+    "description": "[Signup Dialog] Password confirmation input match error."
+  },
+  "SIGNUP_DIALOG__PASSWORD_CONFIRMATION_INPUT_REQUIREMENT_ERROR": {
+    "defaultMessage": "Veuillez répéter le mot de passe.",
+    "description": "[Signup Dialog] Password confirmation input requirement error."
+  },
+  "SIGNUP_DIALOG__PASSWORD_INPUT_REQUIREMENT_ERROR": {
+    "defaultMessage": "Veuillez entrer votre mot de passe.",
+    "description": "[Signup Dialog] Password input requirement error."
   },
   "TYZzVl": {
     "defaultMessage": "Étiquette",
@@ -121,7 +173,7 @@
   },
   "YJ9OxG": {
     "defaultMessage": "Votre email",
-    "description": "[Signup Modal] Email input label."
+    "description": "[Signup Dialog] Email input label."
   },
   "YsRqXk": {
     "defaultMessage": "Exporter en CSV",
@@ -153,7 +205,7 @@
   },
   "fWOJDC": {
     "defaultMessage": "Un nouveau mot de passe",
-    "description": "[Signup Modal] Password input label."
+    "description": "[Signup Dialog] Password input label."
   },
   "h4+RiJ": {
     "defaultMessage": "Mettre à jour",
@@ -201,7 +253,7 @@
   },
   "q5x9RM": {
     "defaultMessage": "S’inscrire",
-    "description": "[Signup Modal] Submit button label."
+    "description": "[Signup Dialog] Submit button label."
   },
   "s1Q3aH": {
     "defaultMessage": "Date",
@@ -213,15 +265,15 @@
   },
   "ugMu4J": {
     "defaultMessage": "Email",
-    "description": "[Login Modal] Form email input label."
+    "description": "[Login Dialog] Form email input label."
   },
   "wHB27C": {
     "defaultMessage": "Connexion",
-    "description": "[Login Modal] Modal title."
+    "description": "[Login Dialog] Modal title."
   },
   "xhJCpr": {
     "defaultMessage": "Mot de passe",
-    "description": "[Login Modal] Form password input label."
+    "description": "[Login Dialog] Form password input label."
   },
   "zGNJ13": {
     "defaultMessage": "Utilisateur·rices",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "scripts": {
     "build": "next build",
+    "ci:e2e:check": "sh ./scripts/ci/e2e/check.sh",
+    "ci:e2e:setup": "sh ./scripts/ci/e2e/setup.sh",
     "db:migrate": "prisma migrate deploy",
     "db:seed": "prisma db seed",
     "debug": "envinfo --binaries --system --markdown",
@@ -27,6 +29,7 @@
     "prestart": "sh ./scripts/build/prestart.sh",
     "start": "next start",
     "test": "yarn test:lint && yarn test:type && yarn test:unit",
+    "test:e2e": "playwright test -c ./config/playwright.config.ts",
     "test:lint": "eslint --ext cjs,js,jsx,ts,tsx .",
     "test:type": "tsc -p ./tsconfig.dev.json",
     "test:unit": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config=./config/jest.config.js --detectOpenHandles",

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -17,7 +17,9 @@ async function IndexEndpoint(req: RequestWithAuth, res: NextApiResponse) {
         }
         data.isReady = await isReady()
 
-        res.status(200).json({ data })
+        res.status(200).json({
+          data,
+        })
       } catch (err) {
         handleError(err, ERROR_PATH, res)
       }

--- a/scripts/ci/e2e/check.sh
+++ b/scripts/ci/e2e/check.sh
@@ -1,0 +1,14 @@
+###############################################################################
+# Automatically download and play last CI failed E2E test video.
+
+#!/bin/bash
+
+# Exit when any command fails:
+set -e
+
+# TODO Download the latest failed workflow run `test-results` articfact.
+# i.e.: https://github.com/betagouv/tell-me/actions/runs/2508627750
+# Use https://api.github.com/repos/betagouv/tell-me/actions/runs
+
+rm -Rf ./test-results && unzip ./test-results.zip -d ./test-results
+vlc ./test-results/*/video.webm

--- a/scripts/ci/e2e/setup.sh
+++ b/scripts/ci/e2e/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Exit when any command fails:
+set -e
+
+if [ ! -f "./.env" ]; then
+  cp ./.env.example ./.env
+fi
+
+# https://betagouv.github.io/nexauth/#/initialize?id=development
+yarn nexauth init


### PR DESCRIPTION
It's a bit long but part of it are just missing localized strings in `SignInModal` that have been added to allow text-based selectors in E2E tests.